### PR TITLE
Fixed restricted jobs settings

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -31,15 +31,15 @@ local function spawnBlackmarketPed()
     end
     
     -- Add ox_target interaction
-    exports.ox_target:addLocalEntity(blackmarketPed, {
+   exports.ox_target:addLocalEntity(blackmarketPed, {
         {
-            name = "nu_blackmarket_interact",
-            icon = Config.Target.icon,
-            label = Config.Target.label,
-            distance = Config.Target.distance,
-            onSelect = function()
-                openBlackmarketUI()
-            end
+        name = "nu_blackmarket_interact",
+        icon = Config.Target.icon,
+        label = Config.Target.label,
+        distance = Config.Target.distance,
+        onSelect = function()
+            TriggerServerEvent("nu-blackmarket:server:requestOpenUI")
+        end
         }
     })
     
@@ -280,6 +280,20 @@ end)
 RegisterNUICallback("requestStock", function(data, cb)
     TriggerServerEvent("nu-blackmarket:server:getStock")
     cb("ok")
+end)
+
+
+
+RegisterNetEvent("nu-blackmarket:client:openUIAllowed", function()
+    openBlackmarketUI()
+end)
+
+RegisterNetEvent("nu-blackmarket:client:openUIDenied", function(reason)
+    lib.notify({
+        title = "Black Market",
+        description = reason or "Access denied",
+        type = "error"
+    })
 end)
 
 -- Register client events

--- a/server/main.lua
+++ b/server/main.lua
@@ -159,6 +159,28 @@ local function sendWebhook(playerName, citizenid, items, totalCost)
     })
 end
 
+
+RegisterNetEvent("nu-blackmarket:server:requestOpenUI", function()
+    local src = source
+    local Player = exports.qbx_core:GetPlayer(src)
+    if not Player then return end
+
+    -- Check job restrictions
+    if not checkJobRestrictions(src) then
+        TriggerClientEvent("nu-blackmarket:client:openUIDenied", src, "Access denied due to job restrictions")
+        return
+    end
+
+    -- Check time restrictions
+    if not checkTimeRestrictions() then
+        TriggerClientEvent("nu-blackmarket:client:openUIDenied", src, "Black market is closed at this time")
+        return
+    end
+
+    -- Passed all checks, allow UI open
+    TriggerClientEvent("nu-blackmarket:client:openUIAllowed", src)
+end)
+
 -- Register server events
 RegisterNetEvent("nu-blackmarket:server:getStock", function()
     local source = source


### PR DESCRIPTION
Here i fixed the server side and client side scripts to better reflect job restrictions. Initially the line 

```
  -- Check job restrictions
    if not checkJobRestrictions(source) then
        TriggerClientEvent("nu-blackmarket:client:purchaseResult", source, false, "Access denied due to job restrictions")
        return
    end
```
was the only thing that would stop restricted jobs. and that was by disallowing _purchasing_
Now, the restricted jobs are unable to access the UI at ALL on or off duty. a player has to specifically remove themselves from the restricted job for them to access the black market. this has a server side register and then a client side call back, not relying on a set trigger as it needs to pass checks before the UI is opened